### PR TITLE
Open chrome instead of cat by default

### DIFF
--- a/bashdown
+++ b/bashdown
@@ -19,7 +19,7 @@ if [ "$COMMAND" == "" ]
 then
   if [ "$BASHDOWN_DEFAULT_COMMAND" == "" ]
   then
-    COMMAND="cat"
+    COMMAND="open -a /Applications/Google\ Chrome.app"
   else
     COMMAND=$BASHDOWN_DEFAULT_COMMAND
   fi


### PR DESCRIPTION
After 6 years I've never once used the default cat command and always overridden it as chrome.